### PR TITLE
adding two new settings min/max-text-item-size

### DIFF
--- a/data/org.gnome.GPaste.gschema.xml.in.in
+++ b/data/org.gnome.GPaste.gschema.xml.in.in
@@ -86,5 +86,23 @@
       </_description>
     </key>
 
+    <key name="max-text-item-size" type="u">
+      <range min="0" max="4294967295"/>
+      <default>4294967295</default>
+      <_summary>Max text item size</_summary>
+      <_description>
+        Maximum size of a text item. Anything out of this boundary is ignored.
+      </_description>
+    </key>
+
+    <key name="min-text-item-size" type="u">
+      <range min="0" max="4294967295"/>
+      <default>0</default>
+      <_summary>Min text item size</_summary>
+      <_description>
+        Minimum size of a text item. Anything out of this boundary is ignored.
+      </_description>
+    </key>
+
   </schema>
 </schemalist>

--- a/libgpaste/gpaste-clipboard.c
+++ b/libgpaste/gpaste-clipboard.c
@@ -19,6 +19,8 @@
 
 #include "gpaste-clipboard-private.h"
 
+#include <string.h>
+
 #define G_PASTE_CLIPBOARD_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), G_PASTE_TYPE_CLIPBOARD, GPasteClipboardPrivate))
 
 G_DEFINE_TYPE (GPasteClipboard, g_paste_clipboard, G_TYPE_OBJECT)
@@ -114,6 +116,13 @@ g_paste_clipboard_set_text (GPasteClipboard *self)
     gchar *text = gtk_clipboard_wait_for_text (priv->real);
 
     if (!text)
+        return NULL;
+
+    guint max_size = g_paste_settings_get_max_text_item_size (priv->settings);
+    guint min_size = g_paste_settings_get_min_text_item_size (priv->settings);
+    guint length = (guint) strlen (text);
+
+    if ((length < min_size) || (length > max_size))
         return NULL;
 
     gboolean trim_items = g_paste_settings_get_trim_items (priv->settings);

--- a/libgpaste/gpaste-settings.c
+++ b/libgpaste/gpaste-settings.c
@@ -32,6 +32,8 @@
 #define SAVE_HISTORY_KEY               "save-history"
 #define TRIM_ITEMS_KEY                 "trim-items"
 #define KEYBOARD_SHORTCUT_KEY          "keyboard-shortcut"
+#define MAX_TEXT_ITEM_SIZE_KEY         "max-text-item-size"
+#define MIN_TEXT_ITEM_SIZE_KEY         "min-text-item-size"
 
 G_DEFINE_TYPE (GPasteSettings, g_paste_settings, G_TYPE_OBJECT)
 
@@ -47,6 +49,8 @@ struct _GPasteSettingsPrivate
     gboolean save_history;
     gboolean trim_items;
     gchar *keyboard_shortcut;
+    guint max_text_item_size;
+    guint min_text_item_size;
 };
 
 enum
@@ -135,6 +139,58 @@ g_paste_settings_get_max_displayed_history_size (GPasteSettings *self)
     g_return_val_if_fail (G_PASTE_IS_SETTINGS (self), 0);
 
     return self->priv->max_displayed_history_size;
+}
+
+static void
+g_paste_settings_set_min_text_item_size_from_dconf (GPasteSettings *self)
+{
+    g_return_if_fail (G_PASTE_IS_SETTINGS (self));
+
+    GPasteSettingsPrivate *priv = self->priv;
+
+    priv->min_text_item_size = g_settings_get_uint (priv->settings, MIN_TEXT_ITEM_SIZE_KEY);
+}
+
+/**
+ * g_paste_settings_get_min_text_item_size:
+ * @self: a GPasteSettings instance
+ *
+ * Get the MIN_TEXT_ITEM_SIZE_KEY setting
+ *
+ * Returns: the value of the MIN_TEXT_ITEM_SIZE_KEY setting
+ */
+guint
+g_paste_settings_get_min_text_item_size (GPasteSettings *self)
+{
+    g_return_val_if_fail (G_PASTE_IS_SETTINGS (self), 0);
+
+    return self->priv->min_text_item_size;
+}
+
+static void
+g_paste_settings_set_max_text_item_size_from_dconf (GPasteSettings *self)
+{
+    g_return_if_fail (G_PASTE_IS_SETTINGS (self));
+
+    GPasteSettingsPrivate *priv = self->priv;
+
+    priv->max_text_item_size = g_settings_get_uint (priv->settings, MAX_TEXT_ITEM_SIZE_KEY);
+}
+
+/**
+ * g_paste_settings_get_max_text_item_size:
+ * @self: a GPasteSettings instance
+ *
+ * Get the MAX_TEXT_ITEM_SIZE_KEY setting
+ *
+ * Returns: the value of the MAX_TEXT_ITEM_SIZE_KEY setting
+ */
+guint
+g_paste_settings_get_max_text_item_size (GPasteSettings *self)
+{
+    g_return_val_if_fail (G_PASTE_IS_SETTINGS (self), 0);
+
+    return self->priv->max_text_item_size;
 }
 
 static void
@@ -374,6 +430,10 @@ g_paste_settings_settings_changed (GSettings   *settings,
         g_paste_settings_set_primary_to_history_from_dconf (self);
     else if (g_strcmp0 (key, MAX_HISTORY_SIZE_KEY) == 0)
         g_paste_settings_set_max_history_size_from_dconf (self);
+    else if (g_strcmp0 (key, MAX_TEXT_ITEM_SIZE_KEY) == 0)
+        g_paste_settings_set_max_text_item_size_from_dconf (self);
+    else if (g_strcmp0 (key, MIN_TEXT_ITEM_SIZE_KEY) == 0)
+        g_paste_settings_set_min_text_item_size_from_dconf (self);
     else if (g_strcmp0 (key, MAX_DISPLAYED_HISTORY_SIZE_KEY) == 0)
         g_paste_settings_set_max_displayed_history_size_from_dconf (self);
     else if (g_strcmp0 (key, SYNCHRONIZE_CLIPBOARDS_KEY) == 0)
@@ -426,6 +486,8 @@ g_paste_settings_new (void)
     g_paste_settings_set_save_history_from_dconf (self);
     g_paste_settings_set_trim_items_from_dconf (self);
     g_paste_settings_set_keyboard_shortcut_from_dconf (self);
+    g_paste_settings_set_max_text_item_size_from_dconf(self);
+    g_paste_settings_set_min_text_item_size_from_dconf(self);
 
     g_signal_connect (G_OBJECT (settings),
                       "changed",

--- a/libgpaste/gpaste-settings.h
+++ b/libgpaste/gpaste-settings.h
@@ -42,6 +42,8 @@ typedef struct _GPasteSettingsPrivate GPasteSettingsPrivate;
 GType g_paste_settings_get_type (void);
 gboolean g_paste_settings_get_primary_to_history (GPasteSettings *self);
 guint g_paste_settings_get_max_history_size (GPasteSettings *self);
+guint g_paste_settings_get_min_text_item_size (GPasteSettings *self);
+guint g_paste_settings_get_max_text_item_size (GPasteSettings *self);
 guint g_paste_settings_get_max_displayed_history_size (GPasteSettings *self);
 gboolean g_paste_settings_get_synchronize_clipboards (GPasteSettings *self);
 void g_paste_settings_set_tracking_state (GPasteSettings *self,

--- a/libgpaste/libgpaste.sym
+++ b/libgpaste/libgpaste.sym
@@ -28,6 +28,8 @@ global:
     g_paste_clipboard_new;
     g_paste_settings_get_type;
     g_paste_settings_get_primary_to_history;
+    g_paste_settings_get_min_text_item_size;
+    g_paste_settings_get_max_text_item_size;
     g_paste_settings_get_max_history_size;
     g_paste_settings_get_max_displayed_history_size;
     g_paste_settings_get_synchronize_clipboards;

--- a/src/gpasted/gpasted.vala
+++ b/src/gpasted/gpasted.vala
@@ -44,6 +44,10 @@ namespace GPaste {
             public void add(string selection) {
                 if (selection != null && selection.validate ())
                 {
+                    if (selection.length < this.settings.get_min_text_item_size() ||
+                        selection.length > this.settings.get_max_text_item_size())
+                            return;
+
                     string stripped = selection.strip ();
                     if (stripped != "")
                         this.clipboards_manager.select (new TextItem (this.settings.get_trim_items () ? stripped : selection));


### PR DESCRIPTION
Adding two new configuration values for setting minimum and maximum size of
text clipboard item. Anything bellow/above the limit is ignored and not
sucked into the clipboard.
