### PR TITLE
Fix wrong usage of g_paste_daemon_tracking

### DIFF
--- a/libgpaste-daemon/gpaste-daemon.c
+++ b/libgpaste-daemon/gpaste-daemon.c
@@ -351,7 +351,7 @@ g_paste_daemon_track (GPasteDaemon          *self,
     g_variant_unref (variant);
 
     g_paste_settings_set_track_changes (self->priv->settings, tracking_state);
-    g_paste_daemon_tracking (NULL, tracking_state, self);
+    g_paste_daemon_tracking (self, tracking_state, NULL);
     g_paste_daemon_send_dbus_reply (connection, invocation, NULL);
 }
 


### PR DESCRIPTION
Recent refactorings switched the meaning of the parameters around,
but missed this invocation, leading to a null pointer dereference.

This caused segfaults when setting the tracking state.

 Program received signal SIGSEGV, Segmentation fault.
 0x00007ffff7bd7a7d in g_paste_daemon_tracking
   (self=0x0, tracking_state=1, user_data=0x759820)
   at libgpaste-daemon/gpaste-daemon.c:280
 280         GPasteDaemonPrivate *priv = self->priv;
