### PR TITLE
Gnome-shell - Keyboard navigation when using Ctrl-Alt-H

### DIFF
--- a/src/applets/gnome-shell/extension.js
+++ b/src/applets/gnome-shell/extension.js
@@ -101,6 +101,7 @@ const GPasteIndicator = new Lang.Class({
 
     _showHistory: function() {
         this.menu.open(true);
+        this.menu.firstMenuItem.setActive(true);
     },
 
     _createHistoryItem: function(index) {


### PR DESCRIPTION
When using the keyboard to access the history you are not able to navigate to the items once the menu is activated. This small patch fixes this by activating the menu item.

I'm running GNOME Shell 3.6.3.1 / GPaste 3.0.1.
