### PR TITLE
Use the standard arrow icon

### DIFF
--- a/src/gnome-shell/statusIcon.js
+++ b/src/gnome-shell/statusIcon.js
@@ -35,8 +35,9 @@ const GPasteStatusIcon = new Lang.Class({
             style_class: 'system-status-icon'
         }));
 
-        this.add_child(new St.Label({
-            text: '\u25BE',
+        this.add_child(new St.Icon({
+            style_class: 'popup-menu-arrow',
+            icon_name: 'pan-down-symbolic',
             y_expand: true,
             y_align: Clutter.ActorAlign.CENTER
         }));


### PR DESCRIPTION
Since 3.12, the arrow icon used by GPaste is different from the icon used by the other entries on the top panel.
[Relevant commit](https://git.gnome.org/browse/gnome-shell/commit/?id=88faee4c79f9ed47ea98cd98233e983bd5f96b2b)
