### PR TITLE
Fix screenshot links in AppData files

### DIFF
--- a/data/appdata/org.gnome.GPaste.Applet.appdata.xml.in
+++ b/data/appdata/org.gnome.GPaste.Applet.appdata.xml.in
@@ -15,10 +15,10 @@
   <url type="homepage">http://www.imagination-land.org/tags/GPaste.html</url>
   <screenshots>
     <screenshot width="1024" height="768" type="default">http://www.imagination-land.org/images/GPaste/Applet-1.png</screenshot>
-    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-1.png</screenshot>
-    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-2.png</screenshot>
-    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-3.png</screenshot>
-    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-4.png</screenshot>
+    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-1-1.png</screenshot>
+    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-2-1.png</screenshot>
+    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-3-1.png</screenshot>
+    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-4-1.png</screenshot>
   </screenshots>
   <updatecontact>Marc-Antoine@Perennou.com</updatecontact>
 </application>

--- a/data/appdata/org.gnome.GPaste.Settings.appdata.xml.in
+++ b/data/appdata/org.gnome.GPaste.Settings.appdata.xml.in
@@ -14,10 +14,10 @@
   </description>
   <url type="homepage">http://www.imagination-land.org/tags/GPaste.html</url>
   <screenshots>
-    <screenshot width="629" height="473" type="default">http://www.imagination-land.org/images/GPaste/Settings-1.png</screenshot>
-    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-2.png</screenshot>
-    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-3.png</screenshot>
-    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-4.png</screenshot>
+    <screenshot width="629" height="473" type="default">http://www.imagination-land.org/images/GPaste/Settings-1-1.png</screenshot>
+    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-2-1.png</screenshot>
+    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-3-1.png</screenshot>
+    <screenshot width="629" height="473">http://www.imagination-land.org/images/GPaste/Settings-4-1.png</screenshot>
   </screenshots>
   <updatecontact>Marc-Antoine@Perennou.com</updatecontact>
 </application>


### PR DESCRIPTION
Some screenshot links in Appdata files (org.gnome.GPaste.Applet.appdata.xml + org.gnome.GPaste.Settings.appdata.xml) don't exist.
