### PR TITLE
Add dash in gpaste-applet man page header

### DIFF
--- a/man/1/gpaste-applet.1
+++ b/man/1/gpaste-applet.1
@@ -19,7 +19,7 @@
 .\" License along with this manual; if not, write to the Free
 .\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 .\" Boston, MA  02111-1301  USA.
-.TH GPASTE APPLET 1
+.TH GPASTE\-APPLET 1
 .SH NAME
 GPaste-Applet \- An applet for the GPaste clipboard manager
 


### PR DESCRIPTION
Or else man thinks the section is "APPLET" instead of "1"
