### PR TITLE
hyphen-used-as-minus-sign in man page

### DIFF
--- a/man/1/gpaste.1
+++ b/man/1/gpaste.1
@@ -62,7 +62,7 @@ Add the text into the history
 .br
 .TP
 .B gpaste add-password <name> <password>
-Add the name - password couple to the history
+Add the name \- password couple to the history
 .br
 .TP
 .B gpaste delete-password <name>
@@ -90,7 +90,7 @@ Merge the <number>th items of the history and put the result in the clipboard
 .br
 If foo bar and baz are respectively index 1 3 and 4 in history and you run
 .br
-gpaste merge -d '"' -s ',' 1 3 4
+gpaste merge \-d '"' \-s ',' 1 3 4
 .br
 You will end up with "foo","bar","baz" in your clipboard
 .br


### PR DESCRIPTION
Here's lintian output...

gpaste: hyphen-used-as-minus-sign usr/share/man/man1/gpaste.1.gz:93
 
    This manual page seems to contain a hyphen where a minus sign was
    intended. By default, "-" chars are interpreted as hyphens (U+2010) by
    groff, not as minus signs (U+002D). Since options to programs use minus
    signs (U+002D), this means for example in UTF-8 locales that you cannot
    cut and paste options, nor search for them easily. The Debian groff
    package currently forces "-" to be interpreted as a minus sign due to
    the number of manual pages with this problem, but this is a
    Debian-specific modification and hopefully eventually can be removed.
    
    "-" must be escaped ("\-") to be interpreted as minus. If you really
    intend a hyphen (normally you don't), write it as "\(hy" to emphasise
    that fact. See groff(7) and especially groff_char(7) for details, and
    also the thread starting with
    https://lists.debian.org/debian-devel/2003/debian-devel-200303/msg01481.html
    
    If you use some tool that converts your documentation to groff format,
    this tag may indicate a bug in the tool. Some tools convert dashes of
    any kind to hyphens. The safe way of converting dashes is to convert
    them to "\-".
    
    Because this error can occur very often, Lintian shows only the first 10
    occurrences for each man page and give the number of suppressed
    occurrences. If you want to see all warnings, run Lintian with the
    -d/--debug option.
    
    Refer to /usr/share/doc/groff-base/README.Debian and the groff_char(7)
    manual page for details.