### PR TITLE
gnome-shell-extension: Set Clutter version to be imported to '2'

### DIFF
--- a/src/gnome-shell/deleteButton.js
+++ b/src/gnome-shell/deleteButton.js
@@ -5,7 +5,7 @@
  */
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-imports.gi.versions.Clutter = '1';
+imports.gi.versions.Clutter = '2';
 
 const Lang = imports.lang;
 

--- a/src/gnome-shell/indicator.js
+++ b/src/gnome-shell/indicator.js
@@ -5,7 +5,7 @@
  */
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-imports.gi.versions.Clutter = '1';
+imports.gi.versions.Clutter = '2';
 
 const Gettext = imports.gettext;
 const Lang = imports.lang;

--- a/src/gnome-shell/item.js
+++ b/src/gnome-shell/item.js
@@ -5,7 +5,7 @@
  */
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-imports.gi.versions.Clutter = '1';
+imports.gi.versions.Clutter = '2';
 
 const Lang = imports.lang;
 

--- a/src/gnome-shell/pageSwitcher.js
+++ b/src/gnome-shell/pageSwitcher.js
@@ -5,7 +5,7 @@
  */
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-imports.gi.versions.Clutter = '1';
+imports.gi.versions.Clutter = '2';
 
 const Lang = imports.lang;
 


### PR DESCRIPTION
Various distributions have automatic code inspection in place in order
to get package dependencies set up. Thins like version are translated
to RPM symbols. In case of Clutter, the verstion advertised by Clutter
is '1.0'.

This patch happens to correct wrongly identified dependencies for such distros.