### PR TITLE
Meson fixes

### DIFF
--- a/data/systemd/meson.build
+++ b/data/systemd/meson.build
@@ -2,10 +2,14 @@ configure_file(
   input: 'org.gnome.GPaste.Ui.systemd.in',
   configuration: conf,
   output: 'org.gnome.GPaste.Ui.service',
+  install: get_option('systemd'),
+  install_dir: userunit_dir,
 )
 
 configure_file(
   input: 'org.gnome.GPaste.systemd.in',
   configuration: conf,
   output: 'org.gnome.GPaste.service',
+  install: get_option('systemd'),
+  install_dir: userunit_dir,
 )

--- a/src/libgpaste/meson.build
+++ b/src/libgpaste/meson.build
@@ -141,6 +141,8 @@ libgpaste_inc = include_directories(
   'util',
 )
 
+libgpaste_symbols_file = meson.current_source_dir() / 'libgpaste.sym'
+
 libgpaste = library(
   'gpaste',
   sources: libgpaste_sources,
@@ -148,7 +150,8 @@ libgpaste = library(
   dependencies: libgpaste_deps,
   install: true,
   install_dir: get_option('libdir'),
-   include_directories : libgpaste_inc,
+  include_directories : libgpaste_inc,
+  link_args: ['-Wl,--version-script=' + libgpaste_symbols_file],
 )
 
 libgpaste_internal_dep = declare_dependency(


### PR DESCRIPTION
Two fixes to get the meson build closer to autotools:
- Install systemd user units
- Apply symbol versioning