### PR TITLE
Pass the clutter event to activate()

### DIFF
--- a/src/gnome-shell/indicator.js
+++ b/src/gnome-shell/indicator.js
@@ -112,7 +112,7 @@ class GPasteIndicator extends PanelMenu.Button {
         if (event.has_control_modifier()) {
             const nb = parseInt(event.get_key_unicode());
             if (!isNaN(nb) && nb >= 0 && nb <= 9 && nb < this._history.length) {
-                this._history[nb].activate();
+                this._history[nb].activate(event);
             }
         } else {
             this._maybeUpdateIndexVisibility(event, true);


### PR DESCRIPTION
The activate() method on ui.PopupMenu takes the triggering event as an
argument; in one place where it was called, that argument was not being
passed.

Fixes #299