### PR TITLE
let user service depend on graphical-session

### DIFF
--- a/data/systemd/org.gnome.GPaste.systemd.in
+++ b/data/systemd/org.gnome.GPaste.systemd.in
@@ -1,7 +1,12 @@
 [Unit]
 Description=GPaste daemon
+PartOf=graphical-session.target
+After=graphical-session.target
 
 [Service]
 Type=dbus
 BusName=org.gnome.GPaste
 ExecStart=@pkglibexecdir@/gpaste-daemon
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
- use After to enforce starting only after DISPLAY is available
- use PartOf to stop service when graphical session is stopped (also see [systemd.special(7)](https://www.freedesktop.org/software/systemd/man/systemd.special.html#Special%20Passive%20User%20Units))
- make it installable so it can be enabled and started with the user session
- useful for dependent tools, like https://github.com/jle64/gnome-pass-search-provider