### PR TITLE
docs: fix simple typo, amout -> amount

### DIFF
--- a/src/libgpaste/settings/gpaste-settings.c
+++ b/src/libgpaste/settings/gpaste-settings.c
@@ -377,7 +377,7 @@ UNSIGNED_SETTING (max_history_size, MAX_HISTORY_SIZE)
 /**
  * g_paste_settings_set_max_memory_usage:
  * @self: a #GPasteSettings instance
- * @value: the maximum amout of memory we can use
+ * @value: the maximum amount of memory we can use
  *
  * Change the "max-memory-usage" setting
  */


### PR DESCRIPTION
There is a small typo in src/libgpaste/settings/gpaste-settings.c.

Should read `amount` rather than `amout`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md