### PR TITLE
Reduce default max text size

### DIFF
--- a/data/gsettings/org.gnome.GPaste.gschema.xml.in
+++ b/data/gsettings/org.gnome.GPaste.gschema.xml.in
@@ -90,7 +90,7 @@
 
     <key name="max-text-item-size" type="t">
       <range min="1" max="2147483647"/>
-      <default>2147483647</default>
+      <default>1048575</default>
       <summary>Max text item size</summary>
       <description>
         Maximum size of a text item. Anything out of this boundary is ignored.


### PR DESCRIPTION
I arbitrarily chose (2^20)-1, but certainly something else would be just as good (as long as it's reasonably smaller than (2^31)-1).

Closes #339