### PR TITLE
Remove status icon arrow

### DIFF
--- a/src/gnome-shell/statusIcon.js
+++ b/src/gnome-shell/statusIcon.js
@@ -17,7 +17,5 @@ class GPasteStatusIcon extends St.BoxLayout {
             icon_name: 'edit-paste-symbolic',
             style_class: 'system-status-icon'
         }));
-
-        this.add_child(PopupMenu.arrowIcon(St.Side.BOTTOM));
     }
 });


### PR DESCRIPTION
Gnome 40 removed these. They can no longer be found next to the application menu (left), date/time (center), or the system menu. Here is the default installation, with a couple of extensions:

![https://i.imgur.com/aPx2eDq.png](https://i.imgur.com/aPx2eDq.png)

GPaste is the only left with the down arrow.