### PR TITLE
open gui window at mouse cursor position

### DIFF
--- a/src/ui/gpaste-ui-window.c
+++ b/src/ui/gpaste-ui-window.c
@@ -363,7 +363,7 @@ g_paste_ui_window_new (GtkApplication *app)
     GtkWidget *self = gtk_widget_new (G_PASTE_TYPE_UI_WINDOW,
                                       "application",     app,
                                       "type",            GTK_WINDOW_TOPLEVEL,
-                                      "window-position", GTK_WIN_POS_CENTER_ALWAYS,
+                                      "window-position", GTK_WIN_POS_MOUSE,
                                       "resizable",       FALSE,
                                       "icon-name",       G_PASTE_ICON_NAME,
                                       NULL);


### PR DESCRIPTION
my son recently suggested this change as it makes the global keyboard shortcut (launch the graphical tool) more useful on large screens