### PR TITLE
daemon: Improve warning for history parser state errors

### DIFF
--- a/src/daemon/tmp/gpaste-file-backend.c
+++ b/src/daemon/tmp/gpaste-file-backend.c
@@ -142,6 +142,7 @@ typedef enum
 
 typedef struct
 {
+    const gchar      *history_file_path;
     GList            *history;
     gsize             mem_size;
     State             state;
@@ -161,7 +162,11 @@ typedef struct
 #define ASSERT_STATE(x)                                                                               \
     if (data->state != x)                                                                             \
     {                                                                                                 \
-        g_warning ("Expected state %" G_GINT32_FORMAT ", but got %" G_GINT32_FORMAT, x, data->state); \
+        gint line_number, char_number;                                                                \
+        g_markup_parse_context_get_position (context, &line_number, &char_number);                    \
+        g_warning ("Expected state %" G_GINT32_FORMAT ", but got %" G_GINT32_FORMAT                   \
+                   " in file “%s” at line %" G_GINT32_FORMAT ", column %" G_GINT32_FORMAT ".",        \
+                   x, data->state, data->history_file_path, line_number, char_number);                \
         return;                                                                                       \
     }
 #define SWITCH_STATE(x, y) \
@@ -500,6 +505,7 @@ g_paste_file_backend_read_history_file (const GPasteStorageBackend *self,
             on_error
         };
         Data data = {
+            history_file_path,
             NULL,
             0,
             BEGIN,


### PR DESCRIPTION
This will make it easier to fix corrupted history files.

For example, with this fix I get:

    Expected state 5, but got 4 in file “/home/jtojnar/.local/share/GPaste/history.xml” at line 5117, column 1.

which pointed me to:

    <item kind="Text" uuid="27eff152-c01a-49bd-8e55-4dbad47f63c9">
      <value><![CDATA[previousAttrs]]></value>
      <value mime="text-html"><![CDATA[]]></value>
    </item>
