### PR TITLE
Use Clutter.ActorAlign instead of St.Align

### DIFF
--- a/src/gnome-shell/aboutItem.js
+++ b/src/gnome-shell/aboutItem.js
@@ -6,6 +6,7 @@
 
 import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
+import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
 import St from 'gi://St';
 
@@ -16,7 +17,7 @@ class GPasteAboutItem extends St.Button {
     _init(client, menu) {
         super._init({
             x_expand: true,
-            x_align: St.Align.MIDDLE,
+            x_align: Clutter.ActorAlign.START,
             reactive: true,
             can_focus: true,
             track_hover: true,

--- a/src/gnome-shell/actionButtonActor.js
+++ b/src/gnome-shell/actionButtonActor.js
@@ -6,6 +6,7 @@
 
 import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
+import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
 import St from 'gi://St';
 
@@ -22,7 +23,7 @@ class GPasteActionButtonActor extends St.BoxLayout {
         this.add_child(new St.Bin({
             child: new St.Label({
                 text: label,
-                y_align: St.Align.MIDDLE,
+                y_align: Clutter.ActorAlign.START,
             }),
         }));
     }

--- a/src/gnome-shell/deleteItemPart.js
+++ b/src/gnome-shell/deleteItemPart.js
@@ -4,6 +4,7 @@
  * Copyright (c) 2010-2023, Marc-Antoine Perennou <Marc-Antoine@Perennou.com>
  */
 
+import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
 import St from 'gi://St';
 
@@ -12,7 +13,7 @@ import { GPasteDeleteButton } from './deleteButton.js';
 export const GPasteDeleteItemPart = GObject.registerClass(
 class GPasteDeleteItemPart extends St.Bin {
     _init(client, uuid) {
-        super._init({ x_align: St.Align.END });
+        super._init({ x_align: Clutter.ActorAlign.CENTER });
         this._deleteButton = new GPasteDeleteButton(client, uuid);
         this.child = this._deleteButton;
     }

--- a/src/gnome-shell/emptyHistoryItem.js
+++ b/src/gnome-shell/emptyHistoryItem.js
@@ -6,6 +6,7 @@
 
 import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
+import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
 import GPaste from 'gi://GPaste';
 import St from 'gi://St';
@@ -17,7 +18,7 @@ class GPasteEmptyHistoryItem extends St.Button {
     _init(client, settings, menu) {
         super._init({
             x_expand: true,
-            x_align: St.Align.MIDDLE,
+            x_align: Clutter.ActorAlign.START,
             reactive: true,
             can_focus: true,
             track_hover: true,

--- a/src/gnome-shell/pageItem.js
+++ b/src/gnome-shell/pageItem.js
@@ -4,6 +4,7 @@
  * Copyright (c) 2010-2023, Marc-Antoine Perennou <Marc-Antoine@Perennou.com>
  */
 
+import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
 import St from 'gi://St';
 
@@ -15,7 +16,7 @@ export const GPastePageItem = GObject.registerClass({
     _init(page) {
         super._init({
             label: '' + page,
-            x_align: St.Align.MIDDLE,
+            x_align: Clutter.ActorAlign.START,
             reactive: true,
             can_focus: false,
             track_hover: true,

--- a/src/gnome-shell/uiItem.js
+++ b/src/gnome-shell/uiItem.js
@@ -6,6 +6,7 @@
 
 import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
+import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
 import GPaste from 'gi://GPaste';
 import St from 'gi://St';
@@ -17,7 +18,7 @@ class GPasteUiItem extends St.Button {
     _init(menu) {
         super._init({
             x_expand: true,
-            x_align: St.Align.MIDDLE,
+            x_align: Clutter.ActorAlign.START,
             reactive: true,
             can_focus: true,
             track_hover: true,


### PR DESCRIPTION
St.Align is removed in https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/b45e75c4b99934a8ef12179bd23b1019c0269dbc

Closes https://github.com/Keruspe/GPaste/issues/428