### PR TITLE
gnome-shell: Support 46

### DIFF
--- a/src/gnome-shell/metadata.json.in
+++ b/src/gnome-shell/metadata.json.in
@@ -1,5 +1,5 @@
 {
-    "shell-version": [ "45" ],
+    "shell-version": [ "45", "46" ],
     "session-modes": [ "user" ],
     "uuid": "GPaste@gnome-shell-extensions.gnome.org",
     "name": "GPaste",


### PR DESCRIPTION
Fixes #440

Basic functionality works for me with GNOME Shell 46 on Ubuntu 24.04 LTS