### PR TITLE
g_paste_util_replace: use g_string_replace instead of g_regex_replace_literal

### DIFF
--- a/src/daemon/tmp/gpaste-file-backend.c
+++ b/src/daemon/tmp/gpaste-file-backend.c
@@ -75,7 +75,9 @@ g_paste_file_backend_write_history_item (const GPasteItem *item, GOutputStream *
 static void
 g_paste_file_backend_write_history_file (const GPasteStorageBackend *self,
                                          const gchar                *history_file_path,
-                                         const GList                *history)
+                                         const GList                *history,
+                                         const GPasteStorageAction  action,
+                                         const guint64              index)
 {
     const GPasteSettings *settings = _G_PASTE_STORAGE_BACKEND_GET_CLASS (self)->get_settings (self);
 
@@ -559,7 +561,7 @@ g_paste_file_backend_read_history_file (const GPasteStorageBackend *self,
         g_clear_pointer (&data.text, g_free);
 
         if (data.version != HISTORY_CURRENT)
-            g_paste_file_backend_write_history_file (self, history_file_path, *history);
+            g_paste_file_backend_write_history_file (self, history_file_path, *history, G_PASTE_STORAGE_ACTION_REPLACE, G_PASTE_STORAGE_ALL_ITEMS);
     }
     else
     {

--- a/src/daemon/tmp/gpaste-history.c
+++ b/src/daemon/tmp/gpaste-history.c
@@ -145,8 +145,23 @@ g_paste_history_update (GPasteHistory     *self,
                         guint64            position)
 {
     GPasteHistoryPrivate *priv = g_paste_history_get_instance_private (self);
+    GPasteStorageAction s_action;
 
-    g_paste_storage_backend_write_history (priv->backend, priv->name, priv->history);
+    switch(action)
+    {
+    case G_PASTE_UPDATE_ACTION_REPLACE:
+        s_action = G_PASTE_STORAGE_ACTION_REPLACE;
+        break;
+    case G_PASTE_UPDATE_ACTION_REMOVE:
+        s_action = G_PASTE_STORAGE_ACTION_REMOVE;
+        break;
+    default:
+        s_action = G_PASTE_STORAGE_ACTION_INVALID;
+    }
+
+    g_paste_storage_backend_write_history (priv->backend, priv->name, priv->history,
+                                           s_action,
+                                           target == G_PASTE_UPDATE_TARGET_ALL ? G_PASTE_STORAGE_ALL_ITEMS : target);
 
     g_debug ("history: update");
 
@@ -814,7 +829,7 @@ g_paste_history_save (GPasteHistory *self,
     GPasteHistoryPrivate *priv = g_paste_history_get_instance_private (self);
     G_PASTE_LOCK_HISTORY;
 
-    g_paste_storage_backend_write_history (priv->backend, (name) ? name : priv->name, priv->history);
+    g_paste_storage_backend_write_history (priv->backend, (name) ? name : priv->name, priv->history, G_PASTE_STORAGE_ACTION_REPLACE, -1);
 }
 
 static void

--- a/src/daemon/tmp/gpaste-storage-backend.c
+++ b/src/daemon/tmp/gpaste-storage-backend.c
@@ -52,19 +52,23 @@ g_paste_storage_backend_read_history (const GPasteStorageBackend *self,
  * @self: a #GPasteItem instance
  * @name: the name of the history to save
  * @history: (element-type GPasteItem): the history to write
+ * @action: what do do with element (replace / remove)
+ * @index: which element to act on, G_PASTE_STORAGE_ALL_ITEMS if all of them
  *
  * Save the history by writing it to our storage backend
  */
 G_PASTE_VISIBLE void
 g_paste_storage_backend_write_history (const GPasteStorageBackend *self,
                                        const gchar                *name,
-                                       const GList                *history)
+                                       const GList                *history,
+                                       const GPasteStorageAction  action,
+                                       guint64                    index)
 {
     g_return_if_fail (_G_PASTE_IS_STORAGE_BACKEND (self));
 
     g_autofree gchar *history_file_path = _g_paste_storage_backend_get_history_file_path (self, name);
 
-    _G_PASTE_STORAGE_BACKEND_GET_CLASS (self)->write_history_file (self, history_file_path, history);
+    _G_PASTE_STORAGE_BACKEND_GET_CLASS (self)->write_history_file (self, history_file_path, history, action, index);
 }
 
 static void

--- a/src/daemon/tmp/gpaste-storage-backend.h
+++ b/src/daemon/tmp/gpaste-storage-backend.h
@@ -20,6 +20,14 @@ typedef enum {
     G_PASTE_STORAGE_DEFAULT = G_PASTE_STORAGE_FILE
 } GPasteStorage;
 
+typedef enum {
+    G_PASTE_STORAGE_ACTION_REPLACE = 1,
+    G_PASTE_STORAGE_ACTION_REMOVE,
+    G_PASTE_STORAGE_ACTION_INVALID = 0
+} GPasteStorageAction;
+
+#define G_PASTE_STORAGE_ALL_ITEMS    G_MAXUINT64
+
 #define G_PASTE_TYPE_STORAGE_BACKEND (g_paste_storage_backend_get_type ())
 
 G_PASTE_DERIVABLE_TYPE (StorageBackend, storage_backend, STORAGE_BACKEND, GObject)
@@ -35,7 +43,9 @@ struct _GPasteStorageBackendClass
                                 gsize                      *size);
     void (*write_history_file) (const GPasteStorageBackend *self,
                                 const gchar                *history_file_path,
-                                const GList                *history);
+                                const GList                *history,
+                                const GPasteStorageAction  action,
+                                guint64                    index);
 
     /*< protected >*/
     const gchar          *(*get_extension) (const GPasteStorageBackend *self);
@@ -48,7 +58,9 @@ void g_paste_storage_backend_read_history  (const GPasteStorageBackend *self,
                                             gsize                      *size);
 void g_paste_storage_backend_write_history (const GPasteStorageBackend *self,
                                             const gchar                *name,
-                                            const GList                *history);
+                                            const GList                *history,
+                                            const GPasteStorageAction  action,
+                                            guint64                    index);
 
 GPasteStorageBackend *g_paste_storage_backend_new (GPasteStorage   storage_kind,
                                                    GPasteSettings *settings);

--- a/src/libgpaste/gpaste/gpaste-util.c
+++ b/src/libgpaste/gpaste/gpaste-util.c
@@ -319,18 +319,11 @@ g_paste_util_replace (const gchar *text,
     g_return_val_if_fail (g_utf8_validate (pattern, -1, NULL), NULL);
     g_return_val_if_fail (g_utf8_validate (substitution, -1, NULL), NULL);
 
-    g_autofree gchar *regex_string = g_regex_escape_string (pattern, -1);
-    g_autoptr (GRegex) regex = g_regex_new (regex_string,
-                                            0, /* Compile options */
-                                            0, /* Match options */
-                                            NULL); /* Error */
-    return g_regex_replace_literal (regex,
-                                    text,
-                                    (gssize) -1,
-                                    0, /* Start position */
-                                    substitution,
-                                    0, /* Match options */
-                                    NULL); /* Error */
+    g_autofree GString *gs = g_string_new(text);
+
+    g_string_replace(gs, pattern, substitution, 0);
+
+    return gs->str;
 }
 
 /**


### PR DESCRIPTION
When using gpaste with storage backup, either selecting a history object for usage or saving a new one will cause the whole history to be converted to xml and stored back to the filesystem.

This conversion is usually fast, but if the user keeps a lot of history saved up, it can take up a couple seconds to convert / save.

When selecting a history object, though, this delay can be noticed by the user, since it takes that much time for the selected object to be available in the clipboard.

When verifying with perf, a lot of time is being taken by g_paste_util_xml_encode, moslty by running g_regex_replace_literal in g_paste_util_replace.

g_paste_util_replace, on the other hand, is only used to replace simple strings. Also, it calls g_regex_escape_string() to make sure all possible regex is not enabled in the replacing pattern, effectively causing it to just replace one string by the other.

In this case, why not replace it directly using g_string_replace instead? It's much faster, considering a history of 27000 itens:

With g_string_replace(), this patch's suggestion:
g_paste_storage_backend_write_history: took 364 miliseconds to run g_paste_storage_backend_write_history: took 364 miliseconds to run g_paste_storage_backend_write_history: took 364 miliseconds to run g_paste_storage_backend_write_history: took 365 miliseconds to run g_paste_storage_backend_write_history: took 362 miliseconds to run

With g_regex_replace_literal():
g_paste_storage_backend_write_history: took 1132 miliseconds to run g_paste_storage_backend_write_history: took 1135 miliseconds to run g_paste_storage_backend_write_history: took 1138 miliseconds to run g_paste_storage_backend_write_history: took 1128 miliseconds to run g_paste_storage_backend_write_history: took 1133 miliseconds to run

Saving almost 70% of cpu usage, and making it much more confortable to the user.