### PR TITLE
guint64 is not the same as gsize on 32-bit

### DIFF
--- a/src/daemon/tmp/gpaste-clipboard.c
+++ b/src/daemon/tmp/gpaste-clipboard.c
@@ -328,7 +328,7 @@ _get_clipboard_data_from_special_atom (GtkSelectionData *selection_data,
     if (atom >= G_PASTE_SPECIAL_ATOM_FIRST && atom < G_PASTE_SPECIAL_ATOM_LAST)
     {
         g_autofree guchar *data = NULL;
-        guint64 length = 0;
+        gsize length = 0;
         const gchar *str = g_paste_item_get_special_value (item, atom);
 
         if (str)

--- a/src/daemon/tmp/gpaste-daemon.c
+++ b/src/daemon/tmp/gpaste-daemon.c
@@ -121,7 +121,7 @@ _err (const gchar *name,
 
 static gchar *
 g_paste_daemon_get_dbus_string_parameter (GVariant *parameters,
-                                          guint64  *length)
+                                          gsize    *length)
 {
     GVariantIter parameters_iter;
 
@@ -139,7 +139,7 @@ _variant_iter_read_strings_parameter (GVariantIter *parameters_iter,
 {
     g_autoptr (GVariant) variant1 = g_variant_iter_next_value (parameters_iter);
     g_autoptr (GVariant) variant2 = g_variant_iter_next_value (parameters_iter);
-    guint64 length;
+    gsize length;
 
     *str1 = g_variant_dup_string (variant1, &length);
     *str2 = g_variant_dup_string (variant2, &length);
@@ -255,7 +255,7 @@ g_paste_daemon_private_add (const GPasteDaemonPrivate *priv,
                             GVariant                  *parameters,
                             GPasteDBusError          **err)
 {
-    guint64 length;
+    gsize length;
     g_autofree gchar *text = g_paste_daemon_get_dbus_string_parameter (parameters, &length);
 
     g_paste_daemon_private_do_add (priv, text, length, err);
@@ -267,7 +267,7 @@ g_paste_daemon_private_add_file (const GPasteDaemonPrivate *priv,
                                  GError                   **error,
                                  GPasteDBusError          **err)
 {
-    guint64 length;
+    gsize length;
     g_autofree gchar *file = g_paste_daemon_get_dbus_string_parameter (parameters, &length);
     g_autofree gchar *content = NULL;
 
@@ -486,10 +486,10 @@ g_paste_daemon_private_get_elements (const GPasteDaemonPrivate *priv,
     g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(ss)"));
 
     g_autoptr (GVariant) variant = g_variant_iter_next_value (&parameters_iter);
-    guint64 len;
+    gsize len;
     g_autofree const gchar **uuids = g_variant_get_strv (variant, &len);
 
-    for (guint64 i = 0; i < len; ++i)
+    for (gsize i = 0; i < len; ++i)
     {
         const GPasteItem *item = g_paste_history_get_by_uuid (history, uuids[i]);
         G_PASTE_DBUS_ASSERT_FULL (item, "received no value for this index", NULL);
@@ -614,7 +614,7 @@ g_paste_daemon_private_merge (const GPasteDaemonPrivate *priv,
     _variant_iter_read_strings_parameter (&parameters_iter, &decoration, &separator);
 
     g_autoptr (GVariant) v_uuids = g_variant_iter_next_value (&parameters_iter);
-    guint64 length;
+    gsize length;
     const GStrv uuids = (const GStrv) g_variant_get_strv (v_uuids, &length);
 
     G_PASTE_DBUS_ASSERT (length, "nothing to merge");
@@ -724,7 +724,7 @@ g_paste_daemon_private_replace (const GPasteDaemonPrivate *priv,
 {
     GPasteHistory *history = priv->history;
     GVariantIter parameters_iter;
-    guint64 length;
+    gsize length;
 
     g_variant_iter_init (&parameters_iter, parameters);
 
@@ -751,7 +751,7 @@ g_paste_daemon_private_set_password (const GPasteDaemonPrivate *priv,
 {
     GPasteHistory *history = priv->history;
     GVariantIter parameters_iter;
-    guint64 length;
+    gsize length;
 
     g_variant_iter_init (&parameters_iter, parameters);
 

--- a/src/daemon/tmp/gpaste-file-backend.c
+++ b/src/daemon/tmp/gpaste-file-backend.c
@@ -402,7 +402,7 @@ end_tag (GMarkupParseContext *context G_GNUC_UNUSED,
 static void
 on_text (GMarkupParseContext *context G_GNUC_UNUSED,
          const gchar         *text,
-         guint64              text_len,
+         gsize                text_len,
          gpointer             user_data,
          GError             **error G_GNUC_UNUSED)
 {
@@ -528,7 +528,7 @@ g_paste_file_backend_read_history_file (const GPasteStorageBackend *self,
                                                                G_MARKUP_TREAT_CDATA_AS_TEXT,
                                                                &data,
                                                                NULL);
-        guint64 text_length;
+        gsize text_length;
 
         g_file_get_contents (history_file_path, &text, &text_length, NULL);
         g_markup_parse_context_parse (ctx, text, text_length, NULL);

--- a/src/daemon/tmp/gpaste-history.c
+++ b/src/daemon/tmp/gpaste-history.c
@@ -36,7 +36,7 @@ typedef struct
     GPasteStorageBackend *backend;
     GPasteSettings       *settings;
     GList                *history;
-    guint64               size;
+    gsize                 size;
 
     gchar                *name;
 

--- a/src/daemon/tmp/gpaste-search-provider.c
+++ b/src/daemon/tmp/gpaste-search-provider.c
@@ -33,7 +33,7 @@ G_PASTE_DEFINE_TYPE_WITH_PRIVATE (SearchProvider, search_provider, G_PASTE_TYPE_
 static char *
 g_paste_dbus_get_as_result (GVariant *variant)
 {
-    guint64 _len;
+    gsize _len;
     g_autofree const gchar **r = g_variant_get_strv (variant, &_len);
 
     return g_strjoinv (" ", (gchar **) r);
@@ -183,7 +183,7 @@ g_paste_search_provider_private_get_result_metas (const GPasteSearchProviderPriv
     g_variant_iter_init (&parameters_iter, parameters);
 
     g_autoptr (GVariant) results = g_variant_iter_next_value (&parameters_iter);
-    guint64 len;
+    gsize len;
     g_autofree const gchar **uuids = g_variant_get_strv (results, &len);
 
     if (!len)

--- a/src/libgpaste/gpaste/gpaste-util.c
+++ b/src/libgpaste/gpaste/gpaste-util.c
@@ -366,7 +366,7 @@ G_PASTE_VISIBLE guint32 *
 g_paste_util_get_dbus_au_result (GVariant *variant,
                                  guint64  *len)
 {
-    guint64 _len;
+    gsize _len;
     const guint32 *r = g_variant_get_fixed_array (variant, &_len, sizeof (guint32));
     guint32 *ret = g_memdup2 (r, _len * sizeof (guint32));
 


### PR DESCRIPTION
gcc < 14 gave warnings when passing such variable from from incompatible pointer type:
https://buildd.debian.org/status/fetch.php?pkg=gpaste&arch=armhf&ver=45-3&stamp=1721124747&raw=0

gcc 14 turned these warnings into errors:
https://buildd.debian.org/status/fetch.php?pkg=gpaste&arch=armhf&ver=45-4&stamp=1722968009&raw=0