### PR TITLE
gnome-shell: Support 48

### DIFF
--- a/src/gnome-shell/metadata.json.in
+++ b/src/gnome-shell/metadata.json.in
@@ -1,5 +1,5 @@
 {
-    "shell-version": [ "45", "46", "47" ],
+    "shell-version": [ "45", "46", "47", "48" ],
     "session-modes": [ "user" ],
     "uuid": "GPaste@gnome-shell-extensions.gnome.org",
     "name": "GPaste",


### PR DESCRIPTION
With this change, I am using the gpaste GNOME Shell extension on Ubuntu 25.04 with GNOME Shell 48 Beta and it seems to work ok.