### PR TITLE
gnome-shell: keep index badge label in sync with current index

### DIFF
--- a/src/gnome-shell/indicator.js
+++ b/src/gnome-shell/indicator.js
@@ -202,7 +202,7 @@ class GPasteIndicator extends Button {
 
                     for (let index = oldSize; index < newSize; ++index) {
                         let realIndex = index + offset;
-                        let item = new GPasteItem(this._client, elementSize, (realIndex < realSize) ? realIndex : -1);
+                        let item = new GPasteItem(this._client, elementSize, index, (realIndex < realSize) ? realIndex : -1);
                         this.menu.addMenuItem(item, this._headerSize + this._postHeaderSize + index);
                         this._history[index] = item;
                     }

--- a/src/gnome-shell/item.js
+++ b/src/gnome-shell/item.js
@@ -16,7 +16,7 @@ import { GPasteDeleteItemPart } from './deleteItemPart.js';
 
 export const GPasteItem = GObject.registerClass(
 class GPasteItem extends PopupMenuItem {
-    _init(client, size, index) {
+    _init(client, size, slotIndex, index) {
         super._init("");
         this.label.set_x_expand(true);
 
@@ -25,9 +25,9 @@ class GPasteItem extends PopupMenuItem {
         this._fakeIndex = false;
         this._uuid = null;
 
-        if (index <= 10) {
+        if (slotIndex <= 9) {
             this._indexLabel = new St.Label({
-                text: index + ': '
+                text: slotIndex + ': '
             });
             this._indexLabelVisible = false;
         }


### PR DESCRIPTION
Fixes #476.

`GPasteItem` builds its `_indexLabel` text once in `_init` from the constructor's `index` argument. Slots constructed with `index === -1` (empty slots allocated by `indicator.js: _resetMaxDisplayedSize` when `realIndex >= realSize`) get a baked `"-1: "` label. `setIndex` later updates `this._index` but never updates `this._indexLabel.text`, so the displayed badge stays at `-1: ` even after the slot receives a real index.

`setUuid` (search-result mode, `_index === -2`) has the analogous issue: the badge from the slot's prior index persists during search.

This patch updates the badge text inside `setIndex` (mirroring the current index) and clears it in `setUuid`. `Ctrl+N` selection is unaffected (it uses `_history[nb]` directly).

## Test

1. `gpaste-client empty`
2. Log out / log in (Wayland) so the extension initializes with empty history.
3. Copy 5+ items.
4. Open history (`<Ctrl><Alt>H`), hold `Ctrl`.

Before: items show `-1:`. After: items show `0:`, `1:`, `2:`, ... correctly.