### PR TITLE
build: Simplify gsettings compilation for tests

### DIFF
--- a/data/gsettings/meson.build
+++ b/data/gsettings/meson.build
@@ -7,14 +7,6 @@ gschema_xml = configure_file(
 )
 
 # Compile the schema in the build directory for tests
-gschema_target = custom_target(
-  'compile-gsettings',
-  output: 'gschemas.compiled',
-  command: [
-    find_program('glib-compile-schemas'),
-    '--targetdir', meson.current_build_dir(),
-    meson.current_build_dir(),
-  ],
+gnome.compile_schemas(
   depend_files: gschema_xml,
-  build_by_default: true,
 )


### PR DESCRIPTION
b2b615fee1f1c46463fcf0dfbe602c2dfee5efd8 can be made much simpler using the appropriate Meson function:
https://mesonbuild.com/Gnome-module.html#gnomecompile_schemas

It will also automatically set `GSETTINGS_SCHEMA_DIR` for `meson devenv` and tests.
