### PR TITLE
tests: Fix crash when GrabAccelerators is not allowed

### DIFF
--- a/tests/gnome-shell-client/test-gnome-shell-client.c
+++ b/tests/gnome-shell-client/test-gnome-shell-client.c
@@ -71,14 +71,16 @@ main (gint argc, gchar *argv[])
 
     g_print ("Now testing KeyGrabber\n");
     guint32 *actions = g_paste_gnome_shell_client_grab_accelerators_sync (client, gs_accels, &error);
-    for (guint64 i = 0; i < 2; ++i)
-        accels[i].action = actions[i];
-    g_free (actions);
+
     if (error)
     {
         g_error ("Couldn't grab accelerators: %s", error->message);
         return EXIT_FAILURE;
     }
+
+    for (guint64 i = 0; i < 2; ++i)
+        accels[i].action = actions[i];
+    g_free (actions);
 
     accels[2].action = g_paste_gnome_shell_client_grab_accelerator_sync (client, gs_accel, &error);
     if (error)


### PR DESCRIPTION
When `g_paste_gnome_shell_client_grab_accelerators_sync` fails with error such as:

    Couldn't grab accelerators: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: GrabAccelerators is not allowed

the `actions` variable will contain NULL pointer and reading from it will cause a SIGSEGV.

Let’s move the check before the use of the result.
