### PR TITLE
daemon: don't read the clipboard content union without checking its kind

### DIFF
--- a/src/libgpaste/gpaste-daemon/gpaste-clipboard-gdk.c
+++ b/src/libgpaste/gpaste-daemon/gpaste-clipboard-gdk.c
@@ -559,8 +559,12 @@ g_paste_clipboard_gdk_update_on_file_list_ready (GObject      *source_object,
     }
 
     GPasteClipboardGdkPrivate *priv = g_paste_clipboard_gdk_get_instance_private (self);
+    /* content.file_list is only live when kind is FILE_LIST: the field is a union
+     * member, so reading it while a TEXT/IMAGE/COLOR content is held reinterprets
+     * unrelated bytes (a string pointer or an RGBA struct) as a GdkFileList*. */
+    GdkFileList *current_file_list = (priv->content.kind == CLIPBOARD_CONTENT_FILE_LIST) ? priv->content.file_list : NULL;
 
-    if (g_paste_clipboard_file_list_equal (priv->content.file_list, file_list))
+    if (g_paste_clipboard_file_list_equal (current_file_list, file_list))
     {
         g_paste_clipboard_gdk_update_maybe_done (data);
         return;


### PR DESCRIPTION
Hi @Keruspe, one crash I hit while running the app :smile:
thx!

## Summary

`GPasteClipboardContent` stores its payload in a `kind`-tagged union, but `g_paste_clipboard_gdk_update_on_file_list_ready()` reads `priv->content.file_list` unconditionally, without first checking that `kind` is `CLIPBOARD_CONTENT_FILE_LIST`. Nothing resets `priv->content` before the async read, so on the transition *into* a file-list selection the union still holds the previous content — a `gchar *` for text/image, or a `GdkRGBA`'s raw float bits for a colour — and those bytes get dereferenced as a `GdkFileList *` inside `gdk_file_list_get_files()`.

The Meta backend already guards this exact comparison with `priv->content.kind == CLIPBOARD_CONTENT_FILE_LIST &&`, as do the other accessors of the union (`get_text`, `get_image_checksum`, the colour compare); this callsite is the odd one out.

Reproduces reliably: copy some text (or a colour), then copy files in Nautilus. Backtrace, with the bogus pointer as `a`:

```
#0  gdk_file_list_get_files
#1  g_paste_clipboard_file_list_equal (a=0x7a9ab0007aa0, b=0x64f743ba5940)
#2  g_paste_clipboard_gdk_update_on_file_list_ready
```

`a` sits in the shared-library mapping range rather than the heap where every other local lives — consistent with reinterpreted non-pointer bytes rather than a freed pointer.

## Test plan

- [x] Builds clean on `master`
- [x] `meson test` passes (eslint + history)
- [x] Stress-tested rapid clipboard content-type transitions (text → file list); previously crashed reliably, now stable across repeated cycles

## Note

This PR previously also carried two sqlite-branch changes and targeted `sqlite`. Both have been dropped — one was unreachable defensive code (`g_paste_binary_data_new()` already rejects zero-length bytes, so the empty-blob case cannot occur), and one deferred the `history-name` settings handler to an idle callback, which turned out to move state mutation out from under `G_PASTE_LOCK_HISTORY` and to drop intermediate switches, without a demonstrated bug behind it. Retargeted to `master` since this crash is independent of the sqlite work.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
