### PR TITLE
ui: lower the inline image preview size floor from 50 to 16px

### DIFF
--- a/data/gsettings/org.gnome.GPaste.gschema.xml
+++ b/data/gsettings/org.gnome.GPaste.gschema.xml
@@ -50,7 +50,7 @@
     </key>
 
     <key name="images-preview-size" type="t">
-      <range min="50" max="200"/>
+      <range min="16" max="200"/>
       <default>50</default>
       <summary>Size of image previews in pixels</summary>
       <description>

--- a/src/libgpaste/gpaste-gtk4/gpaste-gtk-preferences-images-page.c
+++ b/src/libgpaste/gpaste-gtk4/gpaste-gtk-preferences-images-page.c
@@ -53,7 +53,7 @@ g_paste_gtk_preferences_images_page_new (GPasteSettings *settings)
     g_paste_gtk_preferences_group_add_range_setting (group,
                                                      _("Preview size"),
                                                      G_PASTE_IMAGES_PREVIEW_SIZE_SETTING,
-                                                     50, 200, 10,
+                                                     16, 200, 10,
                                                      settings);
     g_paste_gtk_preferences_page_add_group (G_PASTE_GTK_PREFERENCES_PAGE (self), group);
 


### PR DESCRIPTION
## Summary

50px was needlessly large as a floor for the inline thumbnail shown in the history row. The larger detail preview is already shown on hover, so the inline one can go much smaller for users who want a denser list.

## Test plan

- [x] Built and ran locally; preview slider goes down to 16px and the thumbnail shrinks accordingly

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>