### PR TITLE
ui: actually apply the hover preview size cap

### DIFF
--- a/src/ui/gpaste-ui-item-skeleton.c
+++ b/src/ui/gpaste-ui-item-skeleton.c
@@ -244,7 +244,10 @@ g_paste_ui_item_skeleton_set_thumbnail (GPasteUiItemSkeleton *self,
 
 /* Enlarge the small inline thumbnail to a detail preview on hover: the inline
  * picture is deliberately tiny (images-preview-size), so show the full image,
- * capped and aspect-preserved, in a custom tooltip. */
+ * capped and aspect-preserved, in a custom tooltip.
+ * gtk_widget_set_size_request () only sets a minimum, so it cannot bound the
+ * tooltip's natural size: the paintable must be re-rendered with a capped
+ * intrinsic size instead. */
 static gboolean
 g_paste_ui_item_skeleton_on_thumbnail_query_tooltip (GtkWidget  *widget,
                                                      gint        x        G_GNUC_UNUSED,
@@ -263,19 +266,31 @@ g_paste_ui_item_skeleton_on_thumbnail_query_tooltip (GtkWidget  *widget,
      * once per thumbnail and reuse it (cleared in set_thumbnail/dispose). */
     if (!priv->tooltip_preview)
     {
-        GtkWidget *preview = gtk_picture_new_for_paintable (paintable);
-        gtk_picture_set_content_fit (GTK_PICTURE (preview), GTK_CONTENT_FIT_CONTAIN);
-
         gint width = gdk_paintable_get_intrinsic_width (paintable);
         gint height = gdk_paintable_get_intrinsic_height (paintable);
+        g_autoptr (GdkPaintable) scaled = NULL;
 
+        /* Re-render the paintable at the capped size: the result's intrinsic
+         * size is the one the tooltip lays out with, which set_size_request
+         * alone does not achieve here. */
         if (width > 0 && height > 0)
         {
             gdouble scale = MIN (1.0, MIN ((gdouble) G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE / width,
                                            (gdouble) G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE / height));
-            gtk_widget_set_size_request (preview, width * scale, height * scale);
+            gint target_width  = MAX (1, (gint) (width * scale));
+            gint target_height = MAX (1, (gint) (height * scale));
+            g_autoptr (GtkSnapshot) snapshot = gtk_snapshot_new ();
+            graphene_size_t size = GRAPHENE_SIZE_INIT (target_width, target_height);
+
+            gdk_paintable_snapshot (paintable, GDK_SNAPSHOT (snapshot), target_width, target_height);
+            scaled = gtk_snapshot_to_paintable (snapshot, &size);
         }
-        else
+
+        GtkWidget *preview = gtk_picture_new_for_paintable ((scaled) ? scaled : paintable);
+
+        gtk_picture_set_content_fit (GTK_PICTURE (preview), GTK_CONTENT_FIT_CONTAIN);
+
+        if (!scaled)
             gtk_widget_set_size_request (preview, G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE, G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE);
 
         priv->tooltip_preview = g_object_ref_sink (preview);


### PR DESCRIPTION
Split out of the original PR, per review: this is the cap fix on its own, keeping the existing 400px limit unchanged.

The hover preview already declares a 400px cap, but never applies it. `gtk_widget_set_size_request ()` establishes a minimum, not a maximum, so it cannot bound the tooltip's natural size — `GtkPicture` keeps reporting the source paintable's full intrinsic size. A 3000px screenshot gets a tooltip to match, spanning several monitors instead of the intended 400px.

Re-render the paintable at the capped size with `GtkSnapshot` instead, so the preview's intrinsic size is the one the tooltip lays out with.

This keeps the scaling on the GSK side: the resulting paintable wraps the render node, which still references the original texture, so it rasterizes from the full-resolution source at whatever device scale the display uses — no pixel readback, no blur on HiDPI. It also avoids the gdk-pixbuf round trip, which is doubly deprecated (`gdk_pixbuf_get_from_texture ()` since 4.12, `gdk_texture_new_for_pixbuf ()` since 4.20) and which GTK explicitly discourages.

The 400px value itself is untouched; it just takes effect now.

Tested on a 5760x3420 image at 150% scaling: the tooltip is capped and stays sharp.

The follow-up in #499 proposes replacing the fixed 400 with 90% of the window, as you suggested — kept separate so this one can go in on its own.