### PR TITLE
search-provider: don't pass NULL results to g_variant_new_strv

### DIFF
--- a/src/libgpaste/gpaste-daemon/gpaste-search-provider.c
+++ b/src/libgpaste/gpaste-daemon/gpaste-search-provider.c
@@ -64,7 +64,7 @@ on_search_ready (GObject      *source_object G_GNUC_UNUSED,
     if (error)
         g_warning ("GPaste search failed: %s", error->message);
 
-    GVariant *ans = g_variant_new_strv ((const char * const *) results, -1);
+    GVariant *ans = g_variant_new_strv ((const char * const *) results, results ? -1 : 0);
     g_dbus_method_invocation_return_value (invocation, g_variant_new_tuple (&ans, 1));
 }
 


### PR DESCRIPTION
Fixes #496.

`on_search_ready()` detected the search error but fell through and handed the `NULL`
`results` to `g_variant_new_strv (..., -1)`, which walks the array looking for the
terminator and segfaults.

Since GNOME Shell queries search providers on every keystroke, typing any term of three
or more characters with an unbalanced `[` or `(` in the overview (e.g. `ab[`) kills the
daemon and takes the clipboard history with it.

This returns an empty result set instead — the same thing `_do_search()` already does for
terms shorter than three characters — while still logging the error. An empty set keeps
the overview responsive while the user is mid-word; failing the D-Bus call would also work
but Shell handles the empty set more gracefully.

The `!results` check is separate from `error` so that a NULL-without-error result can't
dereference `error->message`.

### Verification

Before, on `45.3`:

```
gpaste-daemon[…]: error while creating regex: … 'ab[' at char 3: missing terminating ] …
gpaste-daemon[…]: g_variant_new_strv: assertion 'length == 0 || strv != NULL' failed
gpaste-daemon[…]: g_variant_ref_sink: assertion 'value != NULL' failed
systemd[…]: org.gnome.GPaste.service: Main process exited, code=dumped, status=11/SEGV
```

Reproducer:

```sh
gdbus call --session \
  --dest org.gnome.GPaste \
  --object-path /org/gnome/GPaste/SearchProvider \
  --method org.gnome.Shell.SearchProvider2.GetInitialResultSet "['ab[']"
```

Builds cleanly on this branch (`meson setup build -Dgnome-shell=false -Dvapi=false
-Dintrospection=false && ninja -C build`, gcc 15.2, glib 2.88) with no new warnings.

I hit the original crash on the distro package `45.3`; the fix is written against current
`master` (50.6), where the same code path is unchanged.
