### PR TITLE
ui: bound the hover preview by the window instead of a fixed size

### DIFF
--- a/src/ui/gpaste-ui-item-skeleton.c
+++ b/src/ui/gpaste-ui-item-skeleton.c
@@ -244,7 +244,10 @@ g_paste_ui_item_skeleton_set_thumbnail (GPasteUiItemSkeleton *self,
 
 /* Enlarge the small inline thumbnail to a detail preview on hover: the inline
  * picture is deliberately tiny (images-preview-size), so show the full image,
- * capped and aspect-preserved, in a custom tooltip. */
+ * capped and aspect-preserved, in a custom tooltip.
+ * gtk_widget_set_size_request () only sets a minimum, so it cannot bound the
+ * tooltip's natural size: the paintable must be re-rendered with a capped
+ * intrinsic size instead. */
 static gboolean
 g_paste_ui_item_skeleton_on_thumbnail_query_tooltip (GtkWidget  *widget,
                                                      gint        x        G_GNUC_UNUSED,
@@ -263,19 +266,31 @@ g_paste_ui_item_skeleton_on_thumbnail_query_tooltip (GtkWidget  *widget,
      * once per thumbnail and reuse it (cleared in set_thumbnail/dispose). */
     if (!priv->tooltip_preview)
     {
-        GtkWidget *preview = gtk_picture_new_for_paintable (paintable);
-        gtk_picture_set_content_fit (GTK_PICTURE (preview), GTK_CONTENT_FIT_CONTAIN);
-
         gint width = gdk_paintable_get_intrinsic_width (paintable);
         gint height = gdk_paintable_get_intrinsic_height (paintable);
+        g_autoptr (GdkPaintable) scaled = NULL;
 
+        /* Re-render the paintable at the capped size: the result's intrinsic
+         * size is the one the tooltip lays out with, which set_size_request
+         * alone does not achieve here. */
         if (width > 0 && height > 0)
         {
             gdouble scale = MIN (1.0, MIN ((gdouble) G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE / width,
                                            (gdouble) G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE / height));
-            gtk_widget_set_size_request (preview, width * scale, height * scale);
+            gint target_width  = MAX (1, (gint) (width * scale));
+            gint target_height = MAX (1, (gint) (height * scale));
+            g_autoptr (GtkSnapshot) snapshot = gtk_snapshot_new ();
+            graphene_size_t size = GRAPHENE_SIZE_INIT (target_width, target_height);
+
+            gdk_paintable_snapshot (paintable, GDK_SNAPSHOT (snapshot), target_width, target_height);
+            scaled = gtk_snapshot_to_paintable (snapshot, &size);
         }
-        else
+
+        GtkWidget *preview = gtk_picture_new_for_paintable ((scaled) ? scaled : paintable);
+
+        gtk_picture_set_content_fit (GTK_PICTURE (preview), GTK_CONTENT_FIT_CONTAIN);
+
+        if (!scaled)
             gtk_widget_set_size_request (preview, G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE, G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE);
 
         priv->tooltip_preview = g_object_ref_sink (preview);

--- a/src/ui/gpaste-ui-item-skeleton.c
+++ b/src/ui/gpaste-ui-item-skeleton.c
@@ -22,6 +22,8 @@ typedef struct
     GtkInscription *label;
     GtkPicture     *thumbnail;
     GtkWidget      *tooltip_preview; /* cached hover preview, rebuilt on thumbnail change */
+    gint            tooltip_preview_width;  /* cap the cached preview was built for */
+    gint            tooltip_preview_height;
     gboolean        editable;
     gboolean        uploadable;
 } GPasteUiItemSkeletonPrivate;
@@ -239,8 +241,34 @@ g_paste_ui_item_skeleton_set_thumbnail (GPasteUiItemSkeleton *self,
     g_paste_ui_item_skeleton_on_images_preview_changed (priv->settings, NULL, priv);
 }
 
-/* Largest dimension, in pixels, of the hover preview. */
+/* Largest dimension, in pixels, of the hover preview, used until the window
+ * has a size to scale against. */
 #define G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE 400
+
+/* Fraction of the window the hover preview is allowed to cover. */
+#define G_PASTE_UI_ITEM_SKELETON_PREVIEW_RATIO 0.9
+
+/* The preview is bounded by the window rather than by a fixed size: a 400px
+ * cap is cramped on a big screen and overflows a small one. */
+static void
+g_paste_ui_item_skeleton_get_preview_bounds (GtkWidget *widget,
+                                             gint      *max_width,
+                                             gint      *max_height)
+{
+    GtkRoot *root = gtk_widget_get_root (widget);
+
+    *max_width = *max_height = 0;
+
+    if (root)
+    {
+        *max_width = gtk_widget_get_width (GTK_WIDGET (root)) * G_PASTE_UI_ITEM_SKELETON_PREVIEW_RATIO;
+        *max_height = gtk_widget_get_height (GTK_WIDGET (root)) * G_PASTE_UI_ITEM_SKELETON_PREVIEW_RATIO;
+    }
+
+    /* Not realized or not allocated yet: nothing to scale against. */
+    if (*max_width <= 0 || *max_height <= 0)
+        *max_width = *max_height = G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE;
+}
 
 /* Enlarge the small inline thumbnail to a detail preview on hover: the inline
  * picture is deliberately tiny (images-preview-size), so show the full image,
@@ -262,6 +290,19 @@ g_paste_ui_item_skeleton_on_thumbnail_query_tooltip (GtkWidget  *widget,
     if (!paintable)
         return FALSE;
 
+    gint max_width, max_height;
+
+    g_paste_ui_item_skeleton_get_preview_bounds (widget, &max_width, &max_height);
+
+    /* The cache is built for a given bound, so drop it when the window is
+     * resized: nothing else notices that the preview should now differ. */
+    if (max_width != priv->tooltip_preview_width || max_height != priv->tooltip_preview_height)
+    {
+        g_clear_object (&priv->tooltip_preview);
+        priv->tooltip_preview_width = max_width;
+        priv->tooltip_preview_height = max_height;
+    }
+
     /* query-tooltip fires repeatedly while hovering; build the scaled preview
      * once per thumbnail and reuse it (cleared in set_thumbnail/dispose). */
     if (!priv->tooltip_preview)
@@ -275,8 +316,8 @@ g_paste_ui_item_skeleton_on_thumbnail_query_tooltip (GtkWidget  *widget,
          * alone does not achieve here. */
         if (width > 0 && height > 0)
         {
-            gdouble scale = MIN (1.0, MIN ((gdouble) G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE / width,
-                                           (gdouble) G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE / height));
+            gdouble scale = MIN (1.0, MIN ((gdouble) max_width / width,
+                                           (gdouble) max_height / height));
             gint target_width  = MAX (1, (gint) (width * scale));
             gint target_height = MAX (1, (gint) (height * scale));
             g_autoptr (GtkSnapshot) snapshot = gtk_snapshot_new ();
@@ -291,7 +332,7 @@ g_paste_ui_item_skeleton_on_thumbnail_query_tooltip (GtkWidget  *widget,
         gtk_picture_set_content_fit (GTK_PICTURE (preview), GTK_CONTENT_FIT_CONTAIN);
 
         if (!scaled)
-            gtk_widget_set_size_request (preview, G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE, G_PASTE_UI_ITEM_SKELETON_PREVIEW_SIZE);
+            gtk_widget_set_size_request (preview, MIN (max_width, max_height), MIN (max_width, max_height));
 
         priv->tooltip_preview = g_object_ref_sink (preview);
     }


### PR DESCRIPTION
Follow-up to #494, implementing your suggestion of capping the preview relative to the window rather than adding a setting.

**Based on #494** — the first commit is that PR, so please review only the second one here. This can rebase onto master once #494 lands.

A fixed 400px cap does not travel well: it is cramped on a large screen and overflows a small window. This scales the preview to 90% of the window instead, so it stays proportionate to whatever space the user actually gave GPaste.

Some notes on the approach:

- The bound is computed **per axis**, so a wide image gets to use the window's width rather than being throttled by its height. That is closer to "90% of the window" than capping the largest dimension with a single number would be.
- It reads the window via `gtk_widget_get_root ()`, so there is no monitor lookup involved and multi-monitor setups need no special handling.
- The cached preview is built for a specific bound, so it is dropped when that bound changes. A window resize is otherwise invisible to it, since the cache is only rebuilt when the thumbnail changes.
- The 400px constant stays as the fallback for when the window has no allocation yet.

Worth noting that #494 is what made this visible: once the cap actually applied, 400px turned out to be noticeably small in practice, which is what prompted trying your suggestion. For reference, on a 5760x3420 image the preview goes from 400x237 to 720x428 at the default window size, and 1728x1026 maximized on a 1920x1200 logical desktop.

Tested at 150% scaling, including resizing the window while previews are cached.